### PR TITLE
Minor adjustments to critical css

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -31,11 +31,13 @@
 @import "bootstrap/scss/images";
 @import "bootstrap/scss/input-group";
 @import "bootstrap/scss/tables";
+/*! critical:end */
 /*! critical:start|user */
 /*! critical:start|error */
 /*! critical:start|website-section.directory */
 /*! critical:start|subscribe */
 /*! critical:start|content */
+/*! critical:start|magazine-issue */
 @import "bootstrap/scss/breadcrumb";
 /*! critical:end */
 @import "bootstrap/scss/alert";
@@ -80,6 +82,7 @@
 /*! critical:start|website-section.directory */
 /*! critical:start|subscribe */
 /*! critical:start|content */
+/*! critical:start|magazine-issue */
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/breadcrumbs";
 /*! critical:end */
 
@@ -92,7 +95,9 @@
 /*! critical:start */
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/lazyload";
 /*! critical:end */
-/*! critical:start|magazine */
+/*! critical:start|magazine *
+/*! critical:start|magazine-issue */
+/*! critical:start|magazine-publication */
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/magazine-publication-buttons";
 /*! critical:end */
 /*! critical:start */
@@ -156,6 +161,8 @@
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/blocks/latest-podcast";
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/blocks/latest-products-feed";
 /*! critical:start|magazine */
+/*! critical:start|magazine-issue */
+/*! critical:start|magazine-publication */
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/blocks/magazine-publication-card";
 /*! critical:end */
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/blocks/more-products";
@@ -206,6 +213,8 @@
 
 // magazine component
 /*! critical:start|magazine */
+/*! critical:start|magazine-issue */
+/*! critical:start|magazine-publication */
 @import "@parameter1/base-cms-marko-web-theme-monorail-magazine/scss/index";
 /*! critical:end */
 
@@ -219,7 +228,8 @@
 // import theme magazine css
 /*! critical:start|home */
 /*! critical:start|magazine */
-@import "@parameter1/base-cms-marko-web-theme-monorail-magazine/scss/index";
+/*! critical:start|magazine-issue */
+/*! critical:start|magazine-publication */
 @import "./components/magazine";
 /*! critical:end */
 


### PR DESCRIPTION
included breadcrumbs across the board and only include the magazine css critically on magazine-issue|magazine-publication|magazine routes correctly.