### PR TITLE
Remove most popular call at the bottom of pages.

### DIFF
--- a/sites/content.nrwa.org/server/templates/content/company.marko
+++ b/sites/content.nrwa.org/server/templates/content/company.marko
@@ -5,8 +5,4 @@ $ const { id, type, pageNode, ...rest } = input;
   type=type
   page-node=pageNode
   ...rest
->
-  <@section>
-    <theme-client-side-most-popular-block />
-  </@section>
-</global-content-company-layout>
+/>

--- a/sites/content.nrwa.org/server/templates/content/index.marko
+++ b/sites/content.nrwa.org/server/templates/content/index.marko
@@ -5,10 +5,4 @@ $ const { id, type, pageNode, ...rest } = input;
   type=type
   page-node=pageNode
   ...rest
->
-  <@section>
-    <div role="region" aria-label="Most Popular Stories">
-      <theme-client-side-most-popular-block />
-    </div>
-  </@section>
-</global-content-default-layout>
+/>

--- a/sites/content.nrwa.org/server/templates/content/media-gallery.marko
+++ b/sites/content.nrwa.org/server/templates/content/media-gallery.marko
@@ -9,8 +9,4 @@ $ const { id, type, pageNode, ...rest } = input;
   <@section>
      <theme-top-stories-block />
   </@section>
-
-  <@section>
-    <theme-client-side-most-popular-block />
-  </@section>
 </global-content-media-gallery-layout>

--- a/sites/content.nrwa.org/server/templates/content/product.marko
+++ b/sites/content.nrwa.org/server/templates/content/product.marko
@@ -5,8 +5,4 @@ $ const { id, type, pageNode, ...rest } = input;
   type=type
   page-node=pageNode
   ...rest
->
-  <@section>
-    <theme-client-side-most-popular-block />
-  </@section>
-</global-content-product-layout>
+/>

--- a/sites/content.nrwa.org/server/templates/index.marko
+++ b/sites/content.nrwa.org/server/templates/index.marko
@@ -18,8 +18,4 @@ $ const { site } = out.global;
     <theme-section-list-deck-block aliases=["utility-operations", "legislation", "technology"] />
   </@section>
 
-  <@section>
-    <div role="region" aria-label="Most Popular Stories">
-      <theme-client-side-most-popular-block />
-    </div>  </@section>
 </global-website-section-home-layout>

--- a/sites/content.nrwa.org/server/templates/website-section/index.marko
+++ b/sites/content.nrwa.org/server/templates/website-section/index.marko
@@ -5,9 +5,4 @@ $ const { id, alias, name, pageNode } = input;
   alias=alias
   name=name
   page-node=pageNode
->
-
-  <@section>
-    <theme-client-side-most-popular-block />
-  </@section>
-</global-website-section-feed-layout>
+/>

--- a/sites/content.nrwa.org/server/templates/website-section/products.marko
+++ b/sites/content.nrwa.org/server/templates/website-section/products.marko
@@ -5,19 +5,4 @@ $ const { id, alias, name, pageNode } = input;
   alias=alias
   name=name
   page-node=pageNode
->
-  <!-- <@section>
-    <theme-callout-cards-block>
-      <@slot>
-        <global-ccj-top-250-block />
-      </@slot>
-      <@slot>
-        <global-white-papers-block />
-      </@slot>
-    </theme-callout-cards-block>
-  </@section> -->
-
-  <@section>
-    <theme-client-side-most-popular-block />
-  </@section>
-</global-website-section-products-layout>
+/>


### PR DESCRIPTION
This will remove the null response displaying at the bottom of the page